### PR TITLE
CIDetector will now only init once.

### DIFF
--- a/bf/bf/BetterFaceClass/UIImageView+BetterFace.h
+++ b/bf/bf/BetterFaceClass/UIImageView+BetterFace.h
@@ -12,7 +12,6 @@
 
 @property (nonatomic) BOOL needsBetterFace;
 @property (nonatomic) BOOL fast;
-@property (nonatomic) CIDetector *detector;
 
 void hack_uiimageview_bf();
 - (void)setBetterFaceImage:(UIImage *)image;

--- a/bf/bf/BetterFaceClass/UIImageView+BetterFace.m
+++ b/bf/bf/BetterFaceClass/UIImageView+BetterFace.m
@@ -10,6 +10,7 @@
 #import <objc/runtime.h>
 #define BETTER_LAYER_NAME @"BETTER_LAYER_NAME"
 #define GOLDEN_RATIO (0.618)
+static CIDetector *detector;
 
 @implementation UIImageView (BetterFace)
 
@@ -74,14 +75,14 @@ char detectorKey;
         NSDictionary  *opts = [NSDictionary dictionaryWithObject:[self fast] ? CIDetectorAccuracyLow : CIDetectorAccuracyHigh
                                                           forKey:CIDetectorAccuracy];
         
-        if (!self.detector) {
-            self.detector = [CIDetector detectorOfType:CIDetectorTypeFace
+        if (!detector) {
+            detector = [CIDetector detectorOfType:CIDetectorTypeFace
                                                       context:nil
                                                       options:opts];
         }
         
         
-        NSArray* features = [self.detector featuresInImage:image];
+        NSArray* features = [detector featuresInImage:image];
         
         if ([features count] == 0) {
             NSLog(@"no faces");


### PR DESCRIPTION
Core Image Contexts/Detectors should be initted (yes that's made up) as sparsely as possible. The reason being is each time you init one you're using GPU compute and memory. This competes with a things like UIScrollViews which are very GPU intensive.

CIDetector is still very resource hungry and I've only tested this code on an iPad Air for performance where its usable, around 40fps rather than 60fps.
