### PR TITLE
CIDetector as a Singleton

### DIFF
--- a/bf/bf/BetterFaceClass/UIImageView+BetterFace.m
+++ b/bf/bf/BetterFaceClass/UIImageView+BetterFace.m
@@ -71,9 +71,10 @@ char detectorKey;
 {
     dispatch_queue_t queue = dispatch_queue_create("com.croath.betterface.queue", NULL);
     dispatch_async(queue, ^{
-        CIImage* image = [CIImage imageWithCGImage:aImage.CGImage];
-        
-        
+        CIImage* image = aImage.CIImage;
+        if (image == nil) { // just in case the UIImage was created using a CGImage revert to the previous, slower implementation
+            image = [CIImage imageWithCGImage:aImage.CGImage];
+        }
         if (detector == nil) {
             NSDictionary  *opts = [NSDictionary dictionaryWithObject:[self fast] ? CIDetectorAccuracyLow : CIDetectorAccuracyHigh
                                                               forKey:CIDetectorAccuracy];
@@ -81,7 +82,6 @@ char detectorKey;
                                                       context:nil
                                                       options:opts];
         }
-        
         
         NSArray* features = [detector featuresInImage:image];
         


### PR DESCRIPTION
Moved the CIDetector as a singleton as there was some overhead in the creation of new CIDetectors which Apple's Documentation recommends against.
https://developer.apple.com/library/ios/documentation/CoreImage/Reference/CIDetector_Ref/Reference/Reference.html

This should improve the performance of UIImageViews inside scroll views.
